### PR TITLE
Added support for decoding unicode characters in KeePass passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is my PoC implementation for [CVE-2023-32784](https://cve.mitre.org/cgi-bin
 
 My version is a python port of [@vdohney's PoC](https://github.com/vdohney/keepass-password-dumper) along with a few changes and additional features.
 
+03NOV23 - Added support for decoding unicode characters
+
 ## Changes
 
 #

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ This is my PoC implementation for [CVE-2023-32784](https://cve.mitre.org/cgi-bin
 
 My version is a python port of [@vdohney's PoC](https://github.com/vdohney/keepass-password-dumper) along with a few changes and additional features.
 
-03NOV23 - Added support for decoding unicode characters
-
 ## Changes
-
+03NOV23 - Added support for decoding unicode characters
 #
 
 One change, was to use known strings that can be found within the dump file in order to more accurately jump to the location of the masterkey characters. This results in less false positive characters and greatly reduces the amount of time it takes to scan the file. In the case the the strings aren't found in the dump file, the scan will start from the beginning. This option is enabled by default, but if you want to do a full scan instead, you can use `--full-scan`. For these instances, I've also added a `--skip` flag to help speed up the scan. This is done by offsetting the pointer to jump over the the next 1000 bytes as they typically just contain same character repeated multiple. For example, if the character `●e`, was found in the dump file, it would appear like the following:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is my PoC implementation for [CVE-2023-32784](https://cve.mitre.org/cgi-bin
 My version is a python port of [@vdohney's PoC](https://github.com/vdohney/keepass-password-dumper) along with a few changes and additional features.
 
 ## Changes
-03NOV23 - Added support for decoding unicode characters
+03NOV23 - Added support for extended ascii characters
 #
 
 One change, was to use known strings that can be found within the dump file in order to more accurately jump to the location of the masterkey characters. This results in less false positive characters and greatly reduces the amount of time it takes to scan the file. In the case the the strings aren't found in the dump file, the scan will start from the beginning. This option is enabled by default, but if you want to do a full scan instead, you can use `--full-scan`. For these instances, I've also added a `--skip` flag to help speed up the scan. This is done by offsetting the pointer to jump over the the next 1000 bytes as they typically just contain same character repeated multiple. For example, if the character `●e`, was found in the dump file, it would appear like the following:

--- a/keepass_dump.py
+++ b/keepass_dump.py
@@ -176,7 +176,7 @@ class KeePassDump:
                 candidates = b"<{" + b", ".join([c.to_bytes() for c in val]) + b"}>"
             else:
                 candidates = val
-            data = candidates.decode()
+            data = candidates.decode('unicode_escape') # Updated to support decoding Unicode chararacters
             print(data)
             chars.append(data)
         return "".join(chars)
@@ -362,7 +362,7 @@ class KeePassDump:
 
 
 def isAscii(mem_dump, idx) -> bool:
-    return 0x20 <= mem_dump[idx] and mem_dump[idx] <= 0x7E and mem_dump[idx + 1] == 0x00
+    return 0x20 <= mem_dump[idx] and mem_dump[idx] <= 0xFF and mem_dump[idx + 1] == 0x00 # Updated valid bytes to support Unicode chararacters
 
 
 def isAsterisk(x, y) -> bool:

--- a/keepass_dump.py
+++ b/keepass_dump.py
@@ -176,7 +176,7 @@ class KeePassDump:
                 candidates = b"<{" + b", ".join([c.to_bytes() for c in val]) + b"}>"
             else:
                 candidates = val
-            data = candidates.decode('unicode_escape') # Updated to support decoding Unicode chararacters
+            data = candidates.decode()
             print(data)
             chars.append(data)
         return "".join(chars)
@@ -362,7 +362,7 @@ class KeePassDump:
 
 
 def isAscii(mem_dump, idx) -> bool:
-    return 0x20 <= mem_dump[idx] and mem_dump[idx] <= 0xFF and mem_dump[idx + 1] == 0x00 # Updated valid bytes to support Unicode chararacters
+    return 0x20 <= mem_dump[idx] and mem_dump[idx + 1] == 0x00 # Accepts any printable character followed by a null byte
 
 
 def isAsterisk(x, y) -> bool:


### PR DESCRIPTION
While using this awesome tool on some Hack the Box machines I noticed that it didn't support decoding of unicode characters. Increased the byte count in `IsAscii()` to account for unicode characters, and added unicode escaping during the decoding of the bytes in the `Display()` function.